### PR TITLE
fix kube-sriov-device-plugin-amd64 permission denied or sriov.sock: b…

### DIFF
--- a/roles/network-multus/templates/sriovdp.yml
+++ b/roles/network-multus/templates/sriovdp.yml
@@ -85,7 +85,7 @@ spec:
         args:
         - --log-level=10
         securityContext:
-          privileged: false
+          privileged: true
         volumeMounts:
         - name: devicesock
           mountPath: /var/lib/kubelet/device-plugins/


### PR DESCRIPTION
…ind: address already in use

kubevirt 0.19.0 on  openshift 3.11

docker 1.13.1